### PR TITLE
Add google analytics tracking script to site

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -30,6 +30,21 @@
       rel="stylesheet"
       type="text/css"
     />
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-Q5JBE0TK39"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+
+      gtag("config", "G-Q5JBE0TK39");
+    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
This PR adds a `gtag.js` script for Google Analytics, which automatically tracks things like pageviews over time, clicks, links, and other useful information that will be helpful after we release!