### PR TITLE
Add product hunt badge to editor page

### DIFF
--- a/src/components/ProductHunt.tsx
+++ b/src/components/ProductHunt.tsx
@@ -1,0 +1,25 @@
+import { Box, Portal } from "@chakra-ui/react";
+
+function ProductHunt() {
+  return (
+    <Portal>
+      <Box position="absolute" bottom={4} right={4} shadow="xl">
+        <a
+          href="https://www.producthunt.com/posts/composing-studio?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-composing-studio"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=313340&theme=light"
+            alt="Composing Studio - Online music editor with simple real-time collaboration | Product Hunt"
+            style={{ width: 250, height: 54 }}
+            width="250"
+            height="54"
+          />
+        </a>
+      </Box>
+    </Portal>
+  );
+}
+
+export default ProductHunt;

--- a/src/pages/EditorPage.tsx
+++ b/src/pages/EditorPage.tsx
@@ -34,6 +34,7 @@ import ConnectionStatus from "../components/ConnectionStatus";
 import Footer from "../components/Footer";
 import User from "../components/User";
 import Score from "../components/Score";
+import ProductHunt from "../components/ProductHunt";
 import Split from "react-split";
 import "./Split.css";
 
@@ -309,6 +310,8 @@ function EditorPage() {
         </Flex>
       </Flex>
       <Footer />
+
+      <ProductHunt />
     </Flex>
   );
 }


### PR DESCRIPTION
This PR adds a Product Hunt badge to the editor page, to improve our chances of getting some organic traffic from Product Hunt. It's contained in a `<ProductHunt />` component, so we can remove it easily when desired.

### Screenshot

![image](https://user-images.githubusercontent.com/7550632/134290154-3d8f7398-48b1-48b7-a214-400721923dcb.png)
